### PR TITLE
fix: python3.7 compatibility

### DIFF
--- a/video_library/templates/generators/video_category.css
+++ b/video_library/templates/generators/video_category.css
@@ -100,13 +100,13 @@
             }
             .panel-heading .accordion-toggle:after {
                 font-family: 'Glyphicons Halflings';  
-                content: "\e114";   
+                content: "\\e114";   
                 float: right;        
                 color: grey;
 				padding-top: 18px;         
             }
             .panel-heading .accordion-toggle.collapsed:after {
-                content: "\e080";    
+                content: "\\e080";    
             }
             p.video_title{
                 padding:0;


### PR DESCRIPTION
Frappe does some regex when generating translations and this causes things to break with python3.7. This fixes that. 